### PR TITLE
Fix Lighthouse Audit Findings

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,7 +21,6 @@ const cspReportOnly = [
   "connect-src 'self' https://*.sanity.io wss://*.api.sanity.io https://challenges.cloudflare.com",
   "frame-src 'self' https://challenges.cloudflare.com",
   "worker-src 'self' blob:",
-  "upgrade-insecure-requests",
 ].join("; ");
 
 const nextConfig: NextConfig = {

--- a/src/app/(website)/page.tsx
+++ b/src/app/(website)/page.tsx
@@ -61,6 +61,7 @@ export default async function HomePage() {
           alt="Betong og maskinarbeid på Radøy"
           fill
           priority
+          fetchPriority="high"
           sizes="100vw"
           className="object-cover"
         />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,7 +20,7 @@
   --bom-text: #f4f6fa;
   --bom-dim: #cdd3de;
   --bom-muted: #98a2b3;
-  --bom-faint: #6b7689;
+  --bom-faint: #828ca0;
   --bom-line: rgba(255, 255, 255, 0.09);
 
   /* shadcn semantic tokens mapped to the brand palette */

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useActionState, useEffect, useState } from "react";
-import Script from "next/script";
-import { Send, Check } from "lucide-react";
-import { mergeForm, useForm, useTransform } from "@tanstack/react-form-nextjs";
-import type { AnyFieldApi } from "@tanstack/react-form";
 import { submitContact } from "@/app/actions/contact";
 import { contactFormOpts, type ContactFormResult } from "@/lib/contact-schema";
-import { Input } from "./ui/input";
-import { Textarea } from "./ui/textarea";
+import { cn } from "@/lib/utils";
+import type { AnyFieldApi } from "@tanstack/react-form";
+import { mergeForm, useForm, useTransform } from "@tanstack/react-form-nextjs";
+import { Check, Send } from "lucide-react";
+import Script from "next/script";
+import { useActionState, useEffect, useState } from "react";
+import { Button } from "./ui/button";
 import {
   Field,
   FieldError,
@@ -17,8 +17,8 @@ import {
   FieldLegend,
   FieldSet,
 } from "./ui/field";
-import { Button } from "./ui/button";
-import { cn } from "@/lib/utils";
+import { Input } from "./ui/input";
+import { Textarea } from "./ui/textarea";
 
 // Empty formState => mergeForm no-op on mount; the form uses its own defaultValues.
 const initialResult: ContactFormResult = {
@@ -111,6 +111,7 @@ export function ContactForm({
   // Bumped on every error to remount the Turnstile widget so it re-arms with a fresh token —
   // the previous one is spent once verified.
   const [widgetKey, setWidgetKey] = useState(0);
+  const [isActivated, setIsActivated] = useState(false);
 
   const form = useForm({
     ...contactFormOpts,
@@ -161,12 +162,19 @@ export function ContactForm({
           {description}
         </p>
       ) : null}
-      <Script
-        src="https://challenges.cloudflare.com/turnstile/v0/api.js"
-        async
-        defer
-      />
-      <form action={formAction} onSubmit={() => form.handleSubmit()}>
+      {isActivated ? (
+        <Script
+          src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+          async
+          defer
+        />
+      ) : null}
+      <form
+        action={formAction}
+        onSubmit={() => form.handleSubmit()}
+        onFocusCapture={() => setIsActivated(true)}
+        onPointerDownCapture={() => setIsActivated(true)}
+      >
         <FieldSet>
           <FieldLegend className="sr-only">Kontaktskjema</FieldLegend>
           <FieldGroup>
@@ -208,10 +216,11 @@ export function ContactForm({
               className="hidden"
               aria-hidden="true"
             />
-            {siteKey ? (
+            {isActivated && siteKey ? (
               <div
                 key={widgetKey}
                 className="cf-turnstile"
+                data-theme="dark"
                 data-sitekey={siteKey}
               />
             ) : null}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -121,7 +121,7 @@ export function Footer({ info }: { info: Info }) {
             © {companyName(info)} <CopyrightYear />. Alle rettigheter
             forbeholdt.
           </span>
-          <span className="font-mono text-[11px] tracking-[1.5px] text-[#4d5667]">
+          <span className="text-faint font-mono text-[11px] tracking-[1.5px]">
             RADØY · ALVER KOMMUNE
           </span>
         </div>

--- a/src/components/GalleryLightbox.tsx
+++ b/src/components/GalleryLightbox.tsx
@@ -88,7 +88,7 @@ export function GalleryLightbox({ images }: { images: GalleryImage[] }) {
               />
             ) : null}
             {active?.caption ? (
-              <span className="font-mono text-[11px] tracking-[1px] text-[#5a6376]">
+              <span className="text-faint font-mono text-[11px] tracking-[1px]">
                 {active.caption}
               </span>
             ) : null}

--- a/src/components/PlaceholderTile.tsx
+++ b/src/components/PlaceholderTile.tsx
@@ -25,7 +25,7 @@ export function PlaceholderTile({
       }}
     >
       <ImageIcon className="size-[30px] text-[#3a4255]" strokeWidth={1.6} />
-      <span className="px-4 text-center font-mono text-[11px] tracking-[1px] text-[#5a6376]">
+      <span className="text-faint px-4 text-center font-mono text-[11px] tracking-[1px]">
         {label}
       </span>
     </div>


### PR DESCRIPTION
## Fix Lighthouse Audit Findings

- Add `fetchPriority="high"` to the homepage hero image so the LCP image loads at high priority — Next 16 split `priority` into `preload`/`fetchPriority`, so `priority` alone no longer set the hint.
- Defer the Cloudflare Turnstile script until the visitor interacts with the contact form, so it no longer sets a third-party cookie or logs console/cookie issues on initial page load.
- Remove `upgrade-insecure-requests` from the report-only CSP, which Chrome ignores in report-only mode and logged as a console error.
- Raise the faint text colour (`#6b7689` -> `#828ca0`) and swap the hardcoded `#4d5667`/`#5a6376` greys for the `text-faint` token to meet WCAG AA contrast.
