### PR TITLE
Harden Contact Form, Align Node 24, Trim Home JS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.13.0"
+          node-version: "24"
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,10 @@
 - Comments: weigh every word. Keep the non-obvious "why"; cut anything the code or tests already show.
 - Never use emojis. Emojis are not allowed.
 - Always add air around if statements and air above return statements. This is a convention in our codebase to improve readability.
-- use kebab-case for file and directory names. Use PascalCase for component names. Use camelCase for variable and function names.
+- Directories: kebab-case
+- Component modules under src/components/: PascalCase filenames (ContactForm.tsx)
+- Non-component modules: kebab-case (contact-schema.ts)
+- Variables/functions camelCase; components PascalCase
 
 # Code style
 
@@ -28,7 +31,10 @@ You are an expert in TypeScript, Node.js, Next.js App Router, React, Base UI, Zo
 
 # Naming Conventions
 
-- Use lowercase with dashes for directories (e.g., components/auth-wizard).
+- Directories: kebab-case (e.g., components/auth-wizard).
+- Component modules under src/components/: PascalCase filenames (ContactForm.tsx)
+- Non-component modules: kebab-case (contact-schema.ts)
+- Variables/functions camelCase; components PascalCase
 - Favor named exports for components.
 
 # TypeScript Usage
@@ -46,19 +52,21 @@ You are an expert in TypeScript, Node.js, Next.js App Router, React, Base UI, Zo
 
 # UI and Styling
 
-- Use our internal ui package if possible, it uses shadcn/ui with Base UI, and Tailwind for components and styling.
+- Use src/components/ui/* (shadcn + Base UI + Tailwind). Prefer existing primitives.
 - Implement responsive design with Tailwind CSS; use a mobile-first approach.
 
 # Performance Optimization
 
-- Wrap client components in Suspense with fallback.
-- Use dynamic loading for non-critical components.
-- Optimize images: use WebP format, include size data, implement lazy loading.
+- Prefer Server Components by default
+- "use client" only when needed
+- next/dynamic for heavy client-only (Studio pattern src/app/studio/[[...tool]]/Studio.tsx)
+- Images: sizes; priority/fetchPriority only for true LCP hero, not chrome logos
 
 # Key Conventions
 
-- Optimize Web Vitals (LCP, CLS, FID).
+- Optimize Core Web Vitals (LCP, CLS, INP).
 - Follow Next.js docs for Data Fetching, Rendering, and Routing.
+- Preview Next + Cache Components: read docs/adr/0001-preview-next-stack.md before changing Studio loading, load.ts, or next.config.ts cache flags.
 
 # Verification Before Done
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Marketing site for a Norwegian concrete/machine contractor. Next.js 16.3 (App Ro
 
 ## Prerequisites
 
-- Node `>=22.13.0` (CI pins `22.13.0`)
+- Node `>=24.0.0` (see `engines` in `package.json`; `.nvmrc` and CI use 24)
 - pnpm `11.0.8` (see `packageManager` in `package.json`)
 
 ## Setup

--- a/src/app/(website)/page.tsx
+++ b/src/app/(website)/page.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from "next";
-import { ContactForm } from "@/components/ContactForm";
 import { ContactMethodCard } from "@/components/ContactMethodCard";
-import { GalleryLightbox } from "@/components/GalleryLightbox";
 import { KickerLabel } from "@/components/KickerLabel";
 import { NoiseOverlay } from "@/components/NoiseOverlay";
 import { PillarCard } from "@/components/PillarCard";
@@ -20,9 +18,18 @@ import { cn } from "@/lib/utils";
 import { urlForImage } from "@/sanity/lib/image";
 import { loadHome, loadLayout } from "@/sanity/lib/load";
 import { ArrowRight, Mail, MapPin, Phone } from "lucide-react";
+import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+
+const GalleryLightbox = dynamic(() =>
+  import("@/components/GalleryLightbox").then((m) => m.GalleryLightbox),
+);
+
+const ContactForm = dynamic(() =>
+  import("@/components/ContactForm").then((m) => m.ContactForm),
+);
 
 // Default hero photo per HANDOFF (the existing project image on the Sanity CDN). A CMS
 // homePage.heroImage overrides it; this is a visual asset, not page copy.

--- a/src/app/actions/contact.test.ts
+++ b/src/app/actions/contact.test.ts
@@ -305,4 +305,54 @@ describe("submitContact", () => {
     expect(verifyTurnstile).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
   });
+
+  it("VERCEL_ENV=production, no Turnstile secret: generic error, no send", async () => {
+    currentIp = "10.0.0.13";
+    setEnv();
+    vi.stubEnv("VERCEL_ENV", "production");
+    const result = await submitContact(initial, buildForm(validInput));
+
+    expect(result.outcome.status).toBe("error");
+
+    if (result.outcome.status === "error") {
+      expect(result.outcome.message).toBe(
+        "Kunne ikke sende meldingen. Prøv igjen senere.",
+      );
+    }
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("VERCEL_ENV=preview, no Turnstile secret: generic error, no send", async () => {
+    currentIp = "10.0.0.14";
+    setEnv();
+    vi.stubEnv("VERCEL_ENV", "preview");
+    const result = await submitContact(initial, buildForm(validInput));
+
+    expect(result.outcome.status).toBe("error");
+
+    if (result.outcome.status === "error") {
+      expect(result.outcome.message).toBe(
+        "Kunne ikke sende meldingen. Prøv igjen senere.",
+      );
+    }
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("VERCEL_ENV=production, secret set, good token: succeeds and sends", async () => {
+    currentIp = "10.0.0.15";
+    setEnv();
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "ts_secret");
+    verifyTurnstile.mockResolvedValueOnce(true);
+    send.mockResolvedValueOnce({ error: null });
+    const result = await submitContact(
+      initial,
+      buildForm({ ...validInput, token: "tok" }),
+    );
+
+    expect(result.outcome.status).toBe("success");
+    expect(send).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/app/actions/contact.test.ts
+++ b/src/app/actions/contact.test.ts
@@ -49,7 +49,7 @@ type FormFields = {
   name?: string;
   email?: string;
   text?: string;
-  company?: string;
+  honeypot?: string;
   token?: string;
 };
 
@@ -62,7 +62,8 @@ function buildForm(fields: FormFields): FormData {
 
   if (fields.text !== undefined) fd.append("text", fields.text);
 
-  if (fields.company !== undefined) fd.append("company", fields.company);
+  if (fields.honeypot !== undefined)
+    fd.append("website_url_hp", fields.honeypot);
 
   if (fields.token !== undefined) {
     fd.append("cf-turnstile-response", fields.token);
@@ -84,12 +85,12 @@ describe("submitContact", () => {
     vi.clearAllMocks();
   });
 
-  it("honeypot: a non-empty company short-circuits to success without sending", async () => {
+  it("honeypot: a non-empty website_url_hp short-circuits to success without sending", async () => {
     currentIp = "10.0.0.1";
     setEnv();
     const result = await submitContact(
       initial,
-      buildForm({ ...validInput, company: "spam-bot" }),
+      buildForm({ ...validInput, honeypot: "spam-bot" }),
     );
 
     expect(result.outcome.status).toBe("success");

--- a/src/app/actions/contact.test.ts
+++ b/src/app/actions/contact.test.ts
@@ -229,6 +229,27 @@ describe("submitContact", () => {
     }
   });
 
+  it("Resend error after Turnstile verify: resetTurnstile is true", async () => {
+    currentIp = "10.0.0.10";
+    setEnv();
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "ts_secret");
+    verifyTurnstile.mockResolvedValueOnce(true);
+    send.mockResolvedValueOnce({ error: { message: "boom" } });
+    const result = await submitContact(
+      initial,
+      buildForm({ ...validInput, token: "tok" }),
+    );
+
+    expect(result.outcome.status).toBe("error");
+
+    if (result.outcome.status === "error") {
+      expect(result.outcome.message).toBe(
+        "Kunne ikke sende meldingen. Prøv igjen senere.",
+      );
+      expect(result.outcome.resetTurnstile).toBe(true);
+    }
+  });
+
   it("Resend send throws: the outer catch returns the generic error (never throws out)", async () => {
     currentIp = "10.0.0.8";
     setEnv();
@@ -242,5 +263,45 @@ describe("submitContact", () => {
         "Kunne ikke sende meldingen. Prøv igjen senere.",
       );
     }
+  });
+
+  it("Resend throw after Turnstile verify: outer catch sets resetTurnstile true", async () => {
+    currentIp = "10.0.0.11";
+    setEnv();
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "ts_secret");
+    verifyTurnstile.mockResolvedValueOnce(true);
+    send.mockRejectedValueOnce(new Error("network down"));
+    const result = await submitContact(
+      initial,
+      buildForm({ ...validInput, token: "tok" }),
+    );
+
+    expect(result.outcome.status).toBe("error");
+
+    if (result.outcome.status === "error") {
+      expect(result.outcome.message).toBe(
+        "Kunne ikke sende meldingen. Prøv igjen senere.",
+      );
+      expect(result.outcome.resetTurnstile).toBe(true);
+    }
+  });
+
+  it("Turnstile secret set, no token: verify error, no send, resetTurnstile false", async () => {
+    currentIp = "10.0.0.12";
+    setEnv();
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "ts_secret");
+    const result = await submitContact(initial, buildForm(validInput));
+
+    expect(result.outcome.status).toBe("error");
+
+    if (result.outcome.status === "error") {
+      expect(result.outcome.message).toBe(
+        "Verifisering feilet. Last siden på nytt og prøv igjen.",
+      );
+      expect(result.outcome.resetTurnstile).toBe(false);
+    }
+
+    expect(verifyTurnstile).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
   });
 });

--- a/src/app/actions/contact.ts
+++ b/src/app/actions/contact.ts
@@ -63,9 +63,9 @@ export async function submitContact(
 
     // Honeypot — pretend success, never reveal the trap. Read raw (it is not a
     // validated field) so bots short-circuit before validation and send.
-    const company = formData.get("company");
+    const honeypot = formData.get("website_url_hp");
 
-    if (typeof company === "string" && company.length > 0) {
+    if (typeof honeypot === "string" && honeypot.length > 0) {
       return successResult("Takk for din henvendelse!");
     }
 

--- a/src/app/actions/contact.ts
+++ b/src/app/actions/contact.ts
@@ -44,6 +44,23 @@ function successResult(message: string): ContactFormResult {
   return { formState: {}, outcome: { status: "success", message } };
 }
 
+// Turnstile must be configured on Vercel production/preview and any non-Vercel
+// production runtime. Local dev and CI may run tokenless without the secret.
+function isTurnstileRequired(): boolean {
+  const vercelEnv = process.env.VERCEL_ENV;
+
+  if (vercelEnv === "production" || vercelEnv === "preview") {
+    return true;
+  }
+
+  // Non-Vercel production runtime (e.g. NODE_ENV=production without VERCEL_ENV)
+  if (process.env.NODE_ENV === "production" && !vercelEnv) {
+    return true;
+  }
+
+  return false;
+}
+
 export async function submitContact(
   _prev: ContactFormResult,
   formData: FormData,
@@ -88,9 +105,21 @@ export async function submitContact(
       throw e;
     }
 
-    // Run the Turnstile gate only when configured server-side. In dev/CI without
-    // the secret the form works tokenless; in prod a missing/failed token fails closed.
-    if (process.env.TURNSTILE_SECRET_KEY) {
+    // Production-like deploys require Turnstile. Missing secret fails closed with
+    // GENERIC_ERROR (misconfig). Dev/CI without secret stays tokenless. When the
+    // secret is set, missing/failed token fails closed with the verify message.
+    const turnstileSecret = process.env.TURNSTILE_SECRET_KEY;
+    const turnstileRequired = isTurnstileRequired();
+
+    if (turnstileRequired && !turnstileSecret) {
+      console.error(
+        "Contact form misconfigured: TURNSTILE_SECRET_KEY missing in a production-like environment.",
+      );
+
+      return errorResult(GENERIC_ERROR, false);
+    }
+
+    if (turnstileSecret) {
       const token = formData.get("cf-turnstile-response");
 
       if (typeof token === "string" && token.length > 0) {

--- a/src/app/actions/contact.ts
+++ b/src/app/actions/contact.ts
@@ -48,6 +48,10 @@ export async function submitContact(
   _prev: ContactFormResult,
   formData: FormData,
 ): Promise<ContactFormResult> {
+  // Tracks whether verifyTurnstile was called with a non-empty token (spent it).
+  // Declared outside try so the outer catch can pass resetTurnstile correctly.
+  let turnstileSpent = false;
+
   try {
     const ip =
       (await headers()).get("x-forwarded-for")?.split(",")[0]?.trim() ??
@@ -88,15 +92,21 @@ export async function submitContact(
     // the secret the form works tokenless; in prod a missing/failed token fails closed.
     if (process.env.TURNSTILE_SECRET_KEY) {
       const token = formData.get("cf-turnstile-response");
-      const verified =
-        typeof token === "string" && token.length > 0
-          ? await verifyTurnstile(token, ip)
-          : false;
 
-      if (!verified) {
+      if (typeof token === "string" && token.length > 0) {
+        turnstileSpent = true;
+        const verified = await verifyTurnstile(token, ip);
+
+        if (!verified) {
+          return errorResult(
+            "Verifisering feilet. Last siden på nytt og prøv igjen.",
+            true, // verify consumed the token — re-arm the widget
+          );
+        }
+      } else {
         return errorResult(
           "Verifisering feilet. Last siden på nytt og prøv igjen.",
-          true, // verify consumed the token — re-arm the widget
+          false,
         );
       }
     }
@@ -110,7 +120,8 @@ export async function submitContact(
       console.error(
         "Contact form misconfigured: missing Resend env vars (RESEND_API_KEY/RESEND_FROM/CONTACT_TO).",
       );
-      return errorResult(GENERIC_ERROR, true);
+
+      return errorResult(GENERIC_ERROR, turnstileSpent);
     }
 
     const resend = new Resend(apiKey);
@@ -124,7 +135,7 @@ export async function submitContact(
     });
 
     if (error) {
-      return errorResult(GENERIC_ERROR, true);
+      return errorResult(GENERIC_ERROR, turnstileSpent);
     }
 
     return successResult("Takk! Vi tar kontakt så snart som mulig.");
@@ -132,6 +143,6 @@ export async function submitContact(
     // Last line of defense: submitContact must never throw out to the client.
     console.error("Unexpected error in submitContact:", err);
 
-    return errorResult(GENERIC_ERROR);
+    return errorResult(GENERIC_ERROR, turnstileSpent);
   }
 }

--- a/src/app/api/revalidate/route.test.ts
+++ b/src/app/api/revalidate/route.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const parseBody = vi.fn();
+const revalidatePath = vi.fn();
+
+vi.mock("next-sanity/webhook", () => ({
+  parseBody: (...args: unknown[]) => parseBody(...args),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: (...args: unknown[]) => revalidatePath(...args),
+}));
+
+import { POST } from "./route";
+
+function makeReq() {
+  return new NextRequest("http://localhost/api/revalidate", {
+    method: "POST",
+    body: "{}",
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("POST /api/revalidate", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("invalid signature false → 401, revalidatePath not called", async () => {
+    parseBody.mockResolvedValueOnce({ isValidSignature: false });
+
+    const res = await POST(makeReq());
+
+    expect(res.status).toBe(401);
+    expect(await res.text()).toContain("Invalid signature");
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("null signature → 401, revalidatePath not called", async () => {
+    parseBody.mockResolvedValueOnce({ isValidSignature: null });
+
+    const res = await POST(makeReq());
+
+    expect(res.status).toBe(401);
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("valid signature → 200, revalidates layout once", async () => {
+    parseBody.mockResolvedValueOnce({ isValidSignature: true });
+
+    const res = await POST(makeReq());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      revalidated: true,
+      scope: "layout",
+    });
+    expect(revalidatePath).toHaveBeenCalledTimes(1);
+    expect(revalidatePath).toHaveBeenCalledWith("/", "layout");
+  });
+
+  it("passes SANITY_REVALIDATE_SECRET and true to parseBody", async () => {
+    vi.stubEnv("SANITY_REVALIDATE_SECRET", "test-secret");
+    parseBody.mockResolvedValueOnce({ isValidSignature: true });
+
+    const req = makeReq();
+    await POST(req);
+
+    expect(parseBody).toHaveBeenCalledWith(req, "test-secret", true);
+  });
+});

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -7,7 +7,13 @@ import type { AnyFieldApi } from "@tanstack/react-form";
 import { mergeForm, useForm, useTransform } from "@tanstack/react-form-nextjs";
 import { Check, Send } from "lucide-react";
 import Script from "next/script";
-import { useActionState, useEffect, useState } from "react";
+import {
+  useActionState,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { Button } from "./ui/button";
 import {
   Field,
@@ -25,6 +31,20 @@ const initialResult: ContactFormResult = {
   formState: {},
   outcome: { status: "idle" },
 };
+
+// Minimal typing for Cloudflare Turnstile's explicit JS API (api.js).
+type TurnstileApi = {
+  render: (
+    el: HTMLElement,
+    opts: { sitekey: string; theme?: "dark" | "light" },
+  ) => string;
+  reset: (widgetId: string) => void;
+  remove?: (widgetId: string) => void;
+};
+
+function getTurnstile(): TurnstileApi | undefined {
+  return (window as unknown as { turnstile?: TurnstileApi }).turnstile;
+}
 
 function RequiredMark() {
   return <span className="text-primary">*</span>;
@@ -108,10 +128,9 @@ export function ContactForm({
     initialResult,
   );
   const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
-  // Bumped on every error to remount the Turnstile widget so it re-arms with a fresh token —
-  // the previous one is spent once verified.
-  const [widgetKey, setWidgetKey] = useState(0);
   const [isActivated, setIsActivated] = useState(false);
+  const widgetRef = useRef<HTMLDivElement | null>(null);
+  const widgetId = useRef<string | null>(null);
 
   const form = useForm({
     ...contactFormOpts,
@@ -121,13 +140,53 @@ export function ContactForm({
     ),
   });
 
-  // Re-arm Turnstile only when the verify spent the token; a still-valid token
-  // (field error, rate-limit) survives so the visitor needn't re-solve.
+  const mountWidget = useCallback(() => {
+    if (!siteKey || !widgetRef.current || !getTurnstile()) {
+      return;
+    }
+
+    if (widgetId.current) {
+      return;
+    }
+
+    widgetId.current = getTurnstile()!.render(widgetRef.current, {
+      sitekey: siteKey,
+      theme: "dark",
+    });
+  }, [siteKey]);
+
+  // Script may already be cached when isActivated flips — mount if ready.
+  useEffect(() => {
+    if (isActivated && siteKey) {
+      mountWidget();
+    }
+  }, [isActivated, siteKey, mountWidget]);
+
+  // Re-arm via explicit reset when verify spent the token; field/rate-limit
+  // errors leave a still-valid token alone.
   useEffect(() => {
     if (result.outcome.status === "error" && result.outcome.resetTurnstile) {
-      setWidgetKey((k) => k + 1);
+      const id = widgetId.current;
+      const api = getTurnstile();
+
+      if (id && api) {
+        api.reset(id);
+      }
     }
   }, [result]);
+
+  useEffect(() => {
+    return () => {
+      const id = widgetId.current;
+      const api = getTurnstile();
+
+      if (id && api?.remove) {
+        api.remove(id);
+      }
+
+      widgetId.current = null;
+    };
+  }, []);
 
   const panel = cn(
     "rounded-2xl border border-line bg-surface p-[clamp(24px,3vw,36px)]",
@@ -167,6 +226,7 @@ export function ContactForm({
           src="https://challenges.cloudflare.com/turnstile/v0/api.js"
           async
           defer
+          onLoad={mountWidget}
         />
       ) : null}
       <form
@@ -216,14 +276,7 @@ export function ContactForm({
               className="hidden"
               aria-hidden="true"
             />
-            {isActivated && siteKey ? (
-              <div
-                key={widgetKey}
-                className="cf-turnstile"
-                data-theme="dark"
-                data-sitekey={siteKey}
-              />
-            ) : null}
+            {isActivated && siteKey ? <div ref={widgetRef} /> : null}
             {result.outcome.status === "error" ? (
               <p role="alert" className="text-destructive text-sm">
                 {result.outcome.message}

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -267,10 +267,10 @@ export function ContactForm({
                 />
               )}
             </form.Field>
-            {/* Honeypot — hidden from users, must stay empty. Captured by FormData, gated server-side. */}
+            {/* Honeypot — hidden from users, must stay empty. Captured by FormData, gated server-side. name intentionally non-standard to avoid autofill. */}
             <input
               type="text"
-              name="company"
+              name="website_url_hp"
               tabIndex={-1}
               autoComplete="off"
               className="hidden"

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -11,7 +11,6 @@ export function Logo({ className }: { className?: string }) {
       alt="Betong & Maskin AS"
       width={211}
       height={38}
-      priority
       unoptimized
       className={cn("h-[30px] w-auto", className)}
     />

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,8 +1,5 @@
-"use client";
-
-import { mergeProps } from "@base-ui/react/merge-props";
-import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
+import type { ComponentProps } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -32,23 +29,15 @@ const badgeVariants = cva(
 function Badge({
   className,
   variant = "default",
-  render,
   ...props
-}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
-  return useRender({
-    defaultTagName: "span",
-    props: mergeProps<"span">(
-      {
-        className: cn(badgeVariants({ variant }), className),
-      },
-      props,
-    ),
-    render,
-    state: {
-      slot: "badge",
-      variant,
-    },
-  });
+}: ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return (
+    <span
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
 }
 
-export { Badge };
+export { Badge, badgeVariants };

--- a/src/lib/turnstile.test.ts
+++ b/src/lib/turnstile.test.ts
@@ -33,4 +33,24 @@ describe("verifyTurnstile", () => {
     );
     expect(await verifyTurnstile("token")).toBe(false);
   });
+
+  it("returns false when fetch rejects", async () => {
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "secret");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    expect(await verifyTurnstile("token")).toBe(false);
+  });
+
+  it("returns false when response body is non-JSON", async () => {
+    vi.stubEnv("TURNSTILE_SECRET_KEY", "secret");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("not-json", { status: 200 })),
+    );
+    expect(await verifyTurnstile("token")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Harden Contact Form, Align Node 24, Trim Home JS

- Fix contact conversion after failed submits: re-arm Turnstile via explicit `render`/`reset` instead of a broken remount, and set `resetTurnstile` when the token was already spent (including Resend throws).
- Close spam/lead-loss holes: require Turnstile on Vercel production/preview when the secret is missing, and rename the honeypot off the autofill-prone `company` field to `website_url_hp`.
- Cover the Sanity publish webhook with unit tests so cache revalidation cannot regress silently under long-lived Cache Components.
- Align CI and README to Node 24 (matching `engines`/`.nvmrc`) and correct AGENTS.md conventions so agents and humans share the real stack rules.
- Cut home LCP/TBT cost: dynamic-import below-fold ContactForm and GalleryLightbox, make Badge a server component, and drop Logo `priority` so it no longer competes with the hero.
