### PR TITLE
Force-Overwrite Schema.json in Typegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit",
-    "typegen": "sanity schema extract && sanity typegen generate",
+    "typegen": "sanity schema extract --force && sanity typegen generate",
     "test": "vitest run",
     "knip": "knip"
   },


### PR DESCRIPTION
## Force-Overwrite Schema.json in Typegen

- Pass `--force` to `sanity schema extract` so CI typegen can overwrite the committed `schema.json` instead of failing when the file already exists
